### PR TITLE
adds saving file directory so you don't have to navigate to it each time

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# ModCheck
+![ModCheck](https://cdn.7tv.app/emote/60eefb20119bd109472f7f4b/4x)
+
+Minecraft SpeedRun Mods Auto Installer/Updater
+
+original idea by [pistacium](https://github.com/pistacium/ModCheck)
+
+![image](https://user-images.githubusercontent.com/25276450/172102912-455735a5-558f-4330-84c6-fad5bf9aa92b.png)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,0 @@
-# ModCheck
-![ModCheck](https://cdn.7tv.app/emote/60eefb20119bd109472f7f4b/4x)
-
-Minecraft SpeedRun Mods Auto Installer/Updater
-
-original idea by [pistacium](https://github.com/pistacium/ModCheck)
-
-![image](https://user-images.githubusercontent.com/25276450/172102912-455735a5-558f-4330-84c6-fad5bf9aa92b.png)

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'com.redlimerl'
-version '0.5.3'
+version '0.5.4'
 repositories {
     mavenCentral()
 }

--- a/src/main/java/com/pistacium/modcheck/ModCheck.java
+++ b/src/main/java/com/pistacium/modcheck/ModCheck.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.pistacium.modcheck.mod.ModData;
 import com.pistacium.modcheck.mod.version.ModVersion;
+import com.pistacium.modcheck.util.Config;
 import com.pistacium.modcheck.util.ModCheckStatus;
 import com.pistacium.modcheck.util.ModCheckUtils;
 
@@ -31,6 +32,8 @@ public class ModCheck {
     public static final ArrayList<ModVersion> AVAILABLE_VERSIONS = new ArrayList<>();
 
     public static final ArrayList<ModData> AVAILABLE_MODS = new ArrayList<>();
+
+    public static Config config;
 
 
     public static void main(String[] args) {

--- a/src/main/java/com/pistacium/modcheck/ModCheckFrame.java
+++ b/src/main/java/com/pistacium/modcheck/ModCheckFrame.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonParser;
 import com.pistacium.modcheck.mod.ModData;
 import com.pistacium.modcheck.mod.resource.ModResource;
 import com.pistacium.modcheck.mod.version.ModVersion;
+import com.pistacium.modcheck.util.Config;
 import com.pistacium.modcheck.util.ModCheckStatus;
 import com.pistacium.modcheck.util.ModCheckUtils;
 import com.pistacium.modcheck.util.SwingUtils;
@@ -81,7 +82,8 @@ public class ModCheckFrame extends JFrame {
 
         JButton selectPathButton = new JButton("Select Instance Paths");
         selectPathButton.addActionListener(e -> {
-            JFileChooser pathSelector = new JFileChooser();
+            Config instanceDir = ModCheckUtils.readConfig();
+            JFileChooser pathSelector = instanceDir == null ? new JFileChooser() : new JFileChooser(instanceDir.getDir());
             pathSelector.setMultiSelectionEnabled(true);
             pathSelector.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
             pathSelector.setDialogType(JFileChooser.CUSTOM_DIALOG);
@@ -111,6 +113,7 @@ public class ModCheckFrame extends JFrame {
                 }
                 selectedDirLabel.setText("<html>Selected Instances : <br>" + stringBuilder.substring(0, stringBuilder.length() - (stringBuilder.length() != 0 ? 2 : 0)) + "</html>");
             }
+            ModCheckUtils.writeConfig(files[0].getParentFile());
         });
 
         instanceSelectPanel.add(selectPathButton);

--- a/src/main/java/com/pistacium/modcheck/util/Config.java
+++ b/src/main/java/com/pistacium/modcheck/util/Config.java
@@ -1,0 +1,15 @@
+package com.pistacium.modcheck.util;
+
+import java.io.File;
+
+public class Config {
+    final String filepath;
+
+    public Config(String filepath) {
+        this.filepath = filepath;
+    }
+
+    public File getDir() {
+        return new File(filepath);
+    }
+}

--- a/src/main/java/com/pistacium/modcheck/util/ModCheckUtils.java
+++ b/src/main/java/com/pistacium/modcheck/util/ModCheckUtils.java
@@ -1,7 +1,7 @@
 package com.pistacium.modcheck.util;
 
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import com.google.gson.*;
+import com.pistacium.modcheck.ModCheck;
 
 import java.io.*;
 import java.net.HttpURLConnection;
@@ -74,5 +74,35 @@ public class ModCheckUtils {
         }
 
         return url;
+    }
+
+    public static Config readConfig() {
+        Gson gson = new Gson();
+        File file = new File("modcheck.json");
+        if (!file.exists()) {
+            return null;
+        }
+        BufferedReader br = null;
+        try {
+            br = new BufferedReader(new FileReader(file));
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        }
+        assert br != null;
+        return gson.fromJson(br, Config.class);
+    }
+
+    public static void writeConfig(File dir) {
+        File file = new File("modcheck.json");
+        Config config = new Config(dir.getPath());
+        try (Writer writer = new FileWriter(file)) {
+            Gson gson = new GsonBuilder()
+                    .setPrettyPrinting()
+                    .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+                    .create();
+            gson.toJson(config, writer);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
creates a file called `modcheck.json` in the current working directory and puts a single value in it, the string of the parent directory of the first instance in the list of selected instances, which is done when the file picker is closed. This is then read when the file picker is opened again.